### PR TITLE
feat(ci): add ci release and test action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,78 @@
+name: 'publish'
+
+on:
+  push:
+    branches:
+      - 'release/*'
+
+# This workflow will trigger on each push to the `release` branch to create or update a GitHub release, build your app, and upload the artifacts to the release.
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: 'macos-latest' # for Arm based macs (M1 and above).
+            args: '--target aarch64-apple-darwin'
+          - platform: 'macos-latest' # for Intel based macs.
+            args: '--target x86_64-apple-darwin'
+          - platform: 'ubuntu-20.04' # for Tauri v1
+            args: ''
+          - platform: 'windows-latest'
+            args: '--target x86_64-pc-windows-msvc'
+          - platform: 'windows-latest'
+            args: '--target i686-pc-windows-msvc'
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-20.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+        # webkitgtk 4.0 is for Tauri v1
+
+      - name: Update local toolchain
+        run: |
+          rustup update
+          rustup component add clippy
+
+      - name: install frontend dependencies
+        run: pnpm install --prod
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: __VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          releaseName: 'StandUp __VERSION__'
+          releaseBody: 'See the assets to download this version and install.'
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}

--- a/.github/workflows/rust-test.yaml
+++ b/.github/workflows/rust-test.yaml
@@ -1,0 +1,36 @@
+name: 'rust test'
+
+on: push
+
+# This workflow will trigger on each push to the `release` branch to create or update a GitHub release, build your app, and upload the artifacts to the release.
+
+jobs:
+  test-rust:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Setup current commit
+        uses: actions/checkout@v4
+
+      - name: install dependencies (ubuntu only)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+        # webkitgtk 4.0 is for Tauri v1
+
+      - name: Update local toolchain
+        run: |
+          rustup update
+          rustup component add clippy
+
+# TODO: fix code to conformant lint
+#      - name: Lint
+#        run: |
+#          cd src-tauri
+#          cargo fmt -- --check
+#          cargo clippy
+
+      - name: Test
+        run: |
+          cd src-tauri
+          cargo check
+          cargo test --all

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,0 +1,32 @@
+name: 'version check'
+
+on:
+  pull_request:
+    branches:
+      - 'release/*'
+
+# This workflow will trigger on each push to the `release` branch to create or update a GitHub release, build your app, and upload the artifacts to the release.
+
+jobs:
+  check-version:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Setup current commit
+        uses: actions/checkout@v4
+
+      - name: Setup target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: pr_base
+
+      - name: Check version bump
+        run: |
+          head_version=$(jq '.package.version' src-tauri/tauri.conf.json)
+          base_version=$(jq '.package.version' pr_base/src-tauri/tauri.conf.json)
+          if [ "$head_version" = "base_version"  ];then
+            echo "Version conflict"
+            exit 1
+          else
+            echo "Version Changed, LGTM"
+          fi

--- a/.github/workflows/web-test.yaml
+++ b/.github/workflows/web-test.yaml
@@ -1,0 +1,33 @@
+name: 'web test'
+
+on: push
+
+# This workflow will trigger on each push to the `release` branch to create or update a GitHub release, build your app, and upload the artifacts to the release.
+
+jobs:
+  test-web:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Setup current commit
+        uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: install frontend dependencies
+        run: pnpm install
+
+      - name: test frontend
+        run: pnpm run test:ci


### PR DESCRIPTION
# 背景
需要自动化测试和打包来减轻人力成本并降低协作风险

# 方案
添加github action：

* main分支需要pr才能并入
* 所有release 分支的push和创建都会自动建立draft的release
* 所有release根据tauri配置文件的版本号命名
* release不允许直接push但是允许pr直接合入
* 合入release的pr必须变更版本号